### PR TITLE
Replace crate level compiler plugin with local plugin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+#[cfg(test)]
 extern crate num;
 extern crate geo;
 


### PR DESCRIPTION
As far as I know, `#![..]` is used to apply a compiler plugin to the crate as a whole. Using `#[..]` is used to apply a compiler plugin to the following item. In this case, we want to only have the `num` crate enabled for tests.

More info http://doc.rust-lang.org/stable/book/compiler-plugins.html