### PR TITLE
Loosen geo dependency Version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://georust.github.io/rust-geohash/"
 
 [dependencies]
 
-geo = "^0.0.5"
+geo = "~0.0.5"
 
 [dev-dependencies]
 num = "0.1.30"


### PR DESCRIPTION
I'm having an issue where I'm using `geo 0.0.7`, but get issues with `geohash` because it requires exactly `geo 0.0.5`.

I've slackened the dependency version, since this library only uses the `x` and `y` fields on `Coordinate` so having a bit of slack around the version shouldn't really hurt anyone.