### PR TITLE
Bump version to 0.4.x.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 documentation = "https://georust.github.io/rust-geohash/"
 
 [dependencies]
-geo = "~0.3.0"
+geo = "~0.4.0"
 
 [dev-dependencies]
 num = "0.1.30"


### PR DESCRIPTION
This update makes it work with the current version of `rust-geo`. I guess a new version for crates.io is necessary afterwards.